### PR TITLE
Fix model loading path

### DIFF
--- a/main.py
+++ b/main.py
@@ -6,7 +6,11 @@ import pandas as pd
 app = FastAPI(title="Insurance Churn Predictor", version="1.0")
 
 # Load model
-model = joblib.load(r"C:\Users\prudh\OneDrive\Desktop\RAG\Churn_Api\Churn_Model_Pickle.pkl")
+# Use a model path relative to this file to avoid relying on a hard-coded
+# absolute path which will not exist in other environments.
+import os
+model_path = os.path.join(os.path.dirname(__file__), "Churn_Model_Pickle.pkl")
+model = joblib.load(model_path)
 
 
 # Define input structure


### PR DESCRIPTION
## Summary
- fix absolute path bug by using relative path to load the model

## Testing
- `python -m py_compile main.py`
- `python - <<'EOF'
import main
print('loaded model path', main.model_path)
EOF`


------
https://chatgpt.com/codex/tasks/task_e_6852c9aace2083289d726e5e091cef70